### PR TITLE
Support building bwapi with gcc-11

### DIFF
--- a/bwapi/BWAPIClient/Source/Client.cpp
+++ b/bwapi/BWAPIClient/Source/Client.cpp
@@ -1,6 +1,7 @@
 #include <BWAPI/Client/Client.h>
 #include <stdexcept>
 #include <iostream>
+#include <cstring>
 
 #ifndef _WIN32
 #include <sys/mman.h>


### PR DESCRIPTION
`cstring` required, otherwise `memset` and `strncpy` are undefined